### PR TITLE
feat: added ticket block to commit title

### DIFF
--- a/src/main/groovy/com/github/rising3/gradle/semver/conventionalcommits/ChangeLogParser.groovy
+++ b/src/main/groovy/com/github/rising3/gradle/semver/conventionalcommits/ChangeLogParser.groovy
@@ -37,7 +37,7 @@ class ChangeLogParser {
     /**
      *
      */
-    private static final REGEX_TITLE = /^(?<type>[a-z]+)(?<scope>\([a-z]+\)|)(?<bc>!?|): (?<description>.+)\n?$/
+    private static final REGEX_TITLE = /^(?<type>[a-z]+)(?<ticket>-?[0-9]+|)(?<scope>\([a-z]+\)|)(?<bc>!?|): (?<description>.+)\n?$/
 
     /**
      *


### PR DESCRIPTION
Now conventional commits titles are parsed with optional ticket after type. E.g.: 'PROJECT-1234: description'.